### PR TITLE
Discounts invoices

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-# before_action :git_repo
+before_action :git_repo
 
   def git_repo
     @repo = GitRepository.new

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -12,4 +12,8 @@ class Invoice < ApplicationRecord
   def total_revenue
     invoice_items.sum(&:revenue)
   end
+
+  def total_discount_revenue
+    invoice_items.sum(&:discount_revenue)
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -16,4 +16,8 @@ class Invoice < ApplicationRecord
   def total_discount_revenue
     invoice_items.sum(&:discount_revenue)
   end
+
+  def grand_total_revenue
+    total_revenue - total_discount_revenue
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -16,6 +16,10 @@ class InvoiceItem < ApplicationRecord
     unit_price * quantity
   end
 
+  def discount_total
+    discount_price ? revenue - (discount_price * quantity) : 0
+  end
+
   def self.top_sales_date
     select('invoices.*, sum(invoice_items.quantity * invoice_items.unit_price) as total_revenues')
     .joins(:transactions)

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -16,7 +16,7 @@ class InvoiceItem < ApplicationRecord
     unit_price * quantity
   end
 
-  def discount_total
+  def discount_revenue
     discount_price ? revenue - (discount_price * quantity) : 0
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,4 +20,24 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
   </body>
   <!-- Github stats in github_footer_file under views/shared -->
+  <footer>
+    <h3 class="white_glow"><center><%= @repo.repo_name.capitalize %> Repo Stats</center></h3>
+    <table class="table table-striped center table-borderless">
+      <thead>
+        <tr>
+          <th class="white_glow">Usernames:</th>
+          <th class="white_glow">Count:</th>
+        </tr>
+    </thead>
+    <tbody>
+      <% @repo.repo_commits.each do |name, count| %>
+        <tr>
+          <td><%= name %></td>
+          <td><%= count %></td>
+        </tr>
+      <% end %>
+    </tbody>
+    </table>
+    Closed Pull Requests: <%= @repo.repo_pull_requests %>
+  </footer>
 </html>

--- a/app/views/shared/_invoice_information.html.erb
+++ b/app/views/shared/_invoice_information.html.erb
@@ -4,4 +4,6 @@
   <% end %>
   <p>Created on: <%= invoice.created_at.strftime('%A, %B %d, %Y') %></p>
   <p>Total Revenue: <%= number_to_currency(invoice.total_revenue, precision: 2) %></p>
+  <p>Total Discounts: <%= number_to_currency(invoice.total_discount_revenue, precision: 2) %></p>
+  <p>Grand Total: <%= number_to_currency(invoice.grand_total_revenue, precision: 2) %></p>
 </section>

--- a/db/migrate/20210308174118_add_columns_to_invoice_items.rb
+++ b/db/migrate/20210308174118_add_columns_to_invoice_items.rb
@@ -1,0 +1,7 @@
+class AddColumnsToInvoiceItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :invoice_items, :discount_id, :integer
+    add_column :invoice_items, :discount_price, :decimal
+    add_column :invoice_items, :discount_percent, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_06_211703) do
+ActiveRecord::Schema.define(version: 2021_03_08_174118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,9 @@ ActiveRecord::Schema.define(version: 2021_03_06_211703) do
     t.bigint "invoice_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "discount_id"
+    t.decimal "discount_price"
+    t.integer "discount_percent"
     t.index ["invoice_id"], name: "index_invoice_items_on_invoice_id"
     t.index ["item_id"], name: "index_invoice_items_on_item_id"
   end

--- a/lib/tasks/csv_load.rake
+++ b/lib/tasks/csv_load.rake
@@ -113,8 +113,8 @@ namespace :csv_load do
               'csv_load:customers',
               'csv_load:invoices',
               'csv_load:transactions',
-              'csv_load:invoice_items',
-              'csv_load:bulk_discounts']
+              'csv_load:bulk_discounts',
+              'csv_load:invoice_items']
 
     tasks.each do |task|
       Rake::Task[task].execute

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Admin Invoices Show Page' do
+RSpec.describe 'As an admin, when I visit the admin invoice show page' do
   before :each do
     @invoice = Invoice.all.first
     @invoice_item = @invoice.invoice_items.first
@@ -9,62 +9,95 @@ RSpec.describe 'Admin Invoices Show Page' do
     @customer.save
   end
 
-  describe "As an admin, " do
-    describe "When I visit the admin show page" do
-      it "Then I see an invoice's id, status, and created_at date" do
-        visit admin_invoice_path(@invoice)
-        expect(current_path).to eq("/admin/invoices/#{@invoice.id}")
+  it "Then I see an invoice's id, status, and created_at date" do
+    visit admin_invoice_path(@invoice)
+    expect(current_path).to eq("/admin/invoices/#{@invoice.id}")
 
-        expect(page).to have_content("Invoice ##{@invoice.id}")
-        within ".invoice-information" do
-          expect(page).to have_content("Created on: #{@invoice.created_at.strftime('%A, %B %d, %Y')}")
+    expect(page).to have_content("Invoice ##{@invoice.id}")
+    within ".invoice-information" do
+      expect(page).to have_content("Created on: #{@invoice.created_at.strftime('%A, %B %d, %Y')}")
+    end
+  end
+
+  it "And I see the total revenue that will be generated from all of my items on the invoice" do
+    visit admin_invoice_path(@invoice)
+
+    within ".invoice-information" do
+      expect(page).to have_content("Total Revenue: $1,016,156.00")
+      expect(page).to have_content("Total Discounts: $0.00")
+      expect(page).to have_content("Grand Total: $1,016,156.00")
+    end
+  end
+
+  describe "And if there are any discounts applied" do
+    it "I see the total revenue, total discounts, and the adjusted grand total" do
+      merchant = Merchant.first
+      bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
+      inv_item1 = InvoiceItem.create!(unit_price: 0.100e3, status: "packaged", quantity: 10, item_id: 3, invoice_id: 484)
+      invoice484 = Invoice.find(484)
+
+      visit admin_invoice_path(invoice484)
+
+      within ".invoice-information" do
+        expect(page).to have_content("Total Revenue: $1,849,077.00")
+        expect(page).to have_content("Total Discounts: $100.00")
+        expect(page).to have_content("Grand Total: $1,848,977.00")
+      end
+    end
+  end
+
+  it "Then I see the customer full name and address related to that invoice" do
+    visit admin_invoice_path(@invoice)
+
+    within ".invoice-customer" do
+      expect(page).to have_content("Customer:")
+      expect(page).to have_content(@customer.full_name)
+      expect(page).to have_content(@customer.address)
+      expect(page).to have_content("#{@customer.city}, #{@customer.state} #{@customer.zipcode}")
+    end
+  end
+
+  describe "Then I see all of my items on the invoice including:" do
+    it "item name, quantity ordered, price it sold for, and invoice item status" do
+
+      visit admin_invoice_path(@invoice)
+
+      within ".invoice-items" do
+        expect(page).to have_content("Items on this Invoice:")
+
+        within ".invoice-item-#{@invoice_item.id}" do
+          expect(page).to have_content(@invoice_item.item.name)
+          expect(page).to have_content(@invoice_item.quantity)
+          expect(page).to have_content("$78,031.00")
+          expect(page).to have_content(@invoice_item.status.titleize)
         end
       end
-      it "And I see the total revenue that will be generated from all of my items on the invoice" do
-        visit admin_invoice_path(@invoice)
 
-        within ".invoice-information" do
-          expect(page).to have_content("Total Revenue: $1,016,156.00")
-        end
-      end
-      it "Then I see the customer full name and address related to that invoice" do
-        visit admin_invoice_path(@invoice)
-
-        within ".invoice-customer" do
-          expect(page).to have_content("Customer:")
-          expect(page).to have_content(@customer.full_name)
-          expect(page).to have_content(@customer.address)
-          expect(page).to have_content("#{@customer.city}, #{@customer.state} #{@customer.zipcode}")
-        end
-      end
-      describe "Then I see all of my items on the invoice including:" do
-        it "Item name, The quantity of the item ordered, The price the Item sold for,The Invoice Item status" do
-
+      describe 'if there are any applicable discounts' do
+        it "I see the discount amount which is a link to that discount's show page" do
           visit admin_invoice_path(@invoice)
 
-          within ".invoice-items" do
-            expect(page).to have_content("Items on this Invoice:")
-
-            within ".invoice-item-#{@invoice_item.id}" do
-              expect(page).to have_content(@invoice_item.item.name)
-              expect(page).to have_content(@invoice_item.quantity)
-              expect(page).to have_content("$78,031.00")
-              expect(page).to have_content(@invoice_item.status.titleize)
-            end
-          end
         end
-        describe "I see the invoice status is a select field with the current invoice status" do
-          describe "When I click this field I can select a new status and click 'Update Invoice Status'" do
-            it "When I click this button, I am taken back to the same page and see the Invoice status updated" do
-              visit admin_invoice_path(@invoice)
-              @invoice.update(status: :in_progress)
-              page.find(:xpath, "//*[@id='invoice_status']/option[2]").click
-              click_button("Update Invoice")
+      end
+    end
 
-              expect(current_path).to eq(admin_invoice_path(@invoice))
-            end
-          end
-        end
+    it "and the invoice status is a select field with the currrent status selected" do
+      visit admin_invoice_path(@invoice)
+
+      expect(page.has_select?('invoice[status]', selected: "#{@invoice.status}"))
+    end
+
+    describe "When I click status select field, I can select a new status" do
+      it "And I can click 'Update Invoice' and see that the invoice's status is updated" do
+        visit admin_invoice_path(@invoice)
+
+        expect(page.has_select?('invoice[status]', selected: "#{@invoice.status}"))
+        select 'completed', from: 'invoice[status]'
+        click_button("Update Invoice")
+
+        expect(current_path).to eq(admin_invoice_path(@invoice))
+        @invoice.reload
+        expect(page.has_select?('invoice[status]', selected: "#{@invoice.status}"))
       end
     end
   end

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'As a merchant when I visit my bulk discounts index page' do
       visit merchant_bulk_discounts_path(@merchant)
 
       within ".discounts" do
-        expect(page.all('.button_to', count: 3))
+        expect(page.all('.button_to', count: 2))
 
         within "#discount-#{@bd1.id}" do
           expect(page).to have_button("Delete")

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -21,9 +21,16 @@ RSpec.describe BulkDiscount, type: :model do
       it "returns true if there are pending invoice items for a bulk discount" do
         merchant = Merchant.first
         bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
-        bd2 = merchant.bulk_discounts.create!(name: "Discount 2", item_threshold: 15, percent_discount: 15)
 
         expect(bd1.pending_invoice_items?).to eq(true)
+      end
+
+      it "returns false when a discount doesn't apply to any items, or does and has no pending invoices" do
+        merchant = Merchant.fifth
+        bd1 = merchant.bulk_discounts.create!(name: "Discount 2", item_threshold: 10, percent_discount: 10)
+        bd2 = merchant.bulk_discounts.create!(name: "Discount 2", item_threshold: 15, percent_discount: 15)
+
+        expect(bd1.pending_invoice_items?).to eq(false)
         expect(bd2.pending_invoice_items?).to eq(false)
       end
     end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -44,10 +44,22 @@ RSpec.describe InvoiceItem, type: :model do
 
   describe 'instance methods' do
     describe '#revenue' do
-      it "gets revenue of " do
+      it "calculates revenue of invoice item" do
         invoice_item = create(:invoice_item, unit_price: 2.5, quantity: 3)
 
         expect(invoice_item.revenue).to eq(7.5)
+      end
+    end
+
+    describe '#discount_total' do
+      it "calculates total discount when applicable" do
+        merchant = Merchant.first
+        bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
+        inv_item1 = InvoiceItem.create!(unit_price: 0.100e3, status: "packaged", quantity: 10, item_id: 3, invoice_id: 484)
+        inv_item2 = merchant.invoice_items.where("quantity <= 10").first
+
+        expect(inv_item1.discount_total).to eq(0.1e3)
+        expect(inv_item2.discount_total).to eq(0)
       end
     end
 

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -51,15 +51,15 @@ RSpec.describe InvoiceItem, type: :model do
       end
     end
 
-    describe '#discount_total' do
+    describe '#discount_revenue' do
       it "calculates total discount when applicable" do
         merchant = Merchant.first
         bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
         inv_item1 = InvoiceItem.create!(unit_price: 0.100e3, status: "packaged", quantity: 10, item_id: 3, invoice_id: 484)
         inv_item2 = merchant.invoice_items.where("quantity <= 10").first
 
-        expect(inv_item1.discount_total).to eq(0.1e3)
-        expect(inv_item2.discount_total).to eq(0)
+        expect(inv_item1.discount_revenue).to eq(0.1e3)
+        expect(inv_item2.discount_revenue).to eq(0)
       end
     end
 

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -45,9 +45,66 @@ RSpec.describe InvoiceItem, type: :model do
   describe 'instance methods' do
     describe '#revenue' do
       it "gets revenue of " do
-        invoice_item = create(:invoice_item, unit_price: 2.5, quantity: 3, id: 1000)
+        invoice_item = create(:invoice_item, unit_price: 2.5, quantity: 3)
 
         expect(invoice_item.revenue).to eq(7.5)
+      end
+    end
+
+    describe '#best discount' do
+      it "returns the best merchant discount available if applicable based on quantity, or nil if none" do
+        merchant = Merchant.first
+        bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
+        bd2 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 20)
+        inv_item1 = merchant.invoice_items.where("quantity >= 10").first
+        inv_item2 = merchant.invoice_items.where("quantity <= 10").first
+
+        expect(inv_item1.best_discount).to eq(bd2)
+        expect(inv_item2.best_discount).to be_nil
+      end
+    end
+
+    describe '#discount_percentage' do
+      it "it returns the discount_percent when there is a best discount, or nil" do
+        merchant = Merchant.first
+        bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
+        bd2 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 20)
+        inv_item1 = merchant.invoice_items.where("quantity >= 10").first
+        inv_item2 = merchant.invoice_items.where("quantity <= 10").first
+
+        expect(inv_item1.discount_percentage).to eq(20)
+        expect(inv_item2.discount_percentage).to be_nil
+      end
+    end
+
+    describe '#apply_discount' do
+      it "when invoice_item is created or updated and has best discount, discount_id and discount_price are saved" do
+        merchant = Merchant.first
+        bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
+        bd2 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 15, percent_discount: 15)
+        inv_item1 = InvoiceItem.create!(unit_price: 0.100e3, status: "packaged", quantity: 10, item_id: 3, invoice_id: 484)
+
+        expect(inv_item1.discount_id).to eq(bd1.id)
+        expect(inv_item1.discount_price).to eq(0.9e2)
+
+        inv_item2 = InvoiceItem.find(2654)
+        inv_item2.update!(quantity: 15)
+
+        expect(inv_item2.discount_id).to eq(bd2.id)
+        expect(inv_item2.discount_price).to eq(0.6384095e5)
+      end
+
+      it "when invoice_item has discount and quantity is updated to below item_threshold discount is removed" do
+        merchant = Merchant.first
+        bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
+        inv_item1 = InvoiceItem.create!(unit_price: 0.100e3, status: "packaged", quantity: 10, item_id: 3, invoice_id: 484)
+
+        expect(inv_item1.discount_id).to eq(bd1.id)
+        expect(inv_item1.discount_price).to eq(0.9e2)
+
+        inv_item1.update!(quantity: 8)
+        expect(inv_item1.discount_id).to be_nil
+        expect(inv_item1.discount_price).to be_nil
       end
     end
   end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -55,5 +55,18 @@ RSpec.describe Invoice, type: :model do
         expect(invoice17.total_discount_revenue).to eq(0)
       end
     end
+
+    describe '#grand_total_revenue' do
+      it "returns total_revenue less total_discount_revenue" do
+        merchant = Merchant.first
+        bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
+        inv_item1 = InvoiceItem.create!(unit_price: 0.100e3, status: "packaged", quantity: 10, item_id: 3, invoice_id: 484)
+        invoice484 = Invoice.find(484)
+        invoice17 = Invoice.find(17)
+
+        expect(invoice484.grand_total_revenue).to eq(0.1848977e7)
+        expect(invoice17.grand_total_revenue).to eq(0.2474251e7)
+      end
+    end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -42,5 +42,18 @@ RSpec.describe Invoice, type: :model do
         expect(invoice17.total_revenue).to eq(0.2474251e7)
       end
     end
+
+    describe '#total_discount_revenue' do
+      it "returns sum of any discounts applicable, or 0" do
+        merchant = Merchant.first
+        bd1 = merchant.bulk_discounts.create!(name: "Discount 1", item_threshold: 10, percent_discount: 10)
+        inv_item1 = InvoiceItem.create!(unit_price: 0.100e3, status: "packaged", quantity: 10, item_id: 3, invoice_id: 484)
+        invoice484 = Invoice.find(484)
+        invoice17 = Invoice.find(17)
+
+        expect(invoice484.total_discount_revenue).to eq(0.1e3)
+        expect(invoice17.total_discount_revenue).to eq(0)
+      end
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe Merchant, type: :model do
         expect(Merchant.top_5_by_revenue.first.total_revenue.to_f).to eq(29349736.0)
       end
     end
+
+    describe '::top_5_customers_for_merchant' do
+      it "gets the top 5 customers with successful transactions for a specific merchant" do
+        merchant = Merchant.all.first
+        results = merchant.top_5_customers_by_transactions
+
+        expect(results.first.first_name).to eq("Parker")
+        expect(results.first.transaction_count).to eq(8)
+        expect(results.last.transaction_count).to eq(4)
+        expect(results.include?("Mariah")).to eq(false)
+        expect(results.pluck(:id).count).to eq(5)
+      end
+    end
   end
 
   describe 'instance methods' do
@@ -52,19 +65,6 @@ RSpec.describe Merchant, type: :model do
         create(:invoice_item, item_id: item2.id, invoice_id: invoice1.id, status: :pending)
 
         expect(merchant.distinct_invoices.pluck(:id)).to eq([invoice1.id])
-      end
-    end
-
-    describe '::top_5_customers_for_merchant' do
-      it "gets the top 5 customers with successful transactions for a specific merchant" do
-        merchant = Merchant.all.first
-        results = merchant.top_5_customers_by_transactions
-
-        expect(results.first.first_name).to eq("Parker")
-        expect(results.first.transaction_count).to eq(8)
-        expect(results.last.transaction_count).to eq(4)
-        expect(results.include?("Mariah")).to eq(false)
-        expect(results.pluck(:id).count).to eq(5)
       end
     end
   end


### PR DESCRIPTION
### Add
* `pending_invoices?` edge case tests
* Github API back into footer for all pages
* migrations to add discount_id, discount_price, discount_percent columns to invoice_items table
* `best discount` to invoice item to determine best discount based on quantity
* `discount_percentage` determine discount percent when there is a best dicount
* `apply_discount` before_save callback to add/remove discount to any invoice item when applicable
* methods to calculate discount totals and grand total revenue 
### Update
* csv_load:all put bulk_discounts before invoice_items
* refactor invoice show view feature tests and add proper select testing
* display discount totals and grand total (total revenue less discounts) on all invoice show pages

closes #117 
closes #119 